### PR TITLE
Refunds should be `is_payable`

### DIFF
--- a/classes/Kohana/Model/Purchase/Item/Refund.php
+++ b/classes/Kohana/Model/Purchase/Item/Refund.php
@@ -18,7 +18,7 @@ class Kohana_Model_Purchase_Item_Refund extends Model_Purchase_Item {
 		$meta
 			->fields(array(
 				'is_payable' => Jam::field('boolean', array(
-					'default' => FALSE,
+					'default' => TRUE,
 				)),
 				'is_discount' => Jam::field('boolean', array(
 					'default' => TRUE,

--- a/classes/Kohana/Model/Store/Refund.php
+++ b/classes/Kohana/Model/Store/Refund.php
@@ -38,7 +38,16 @@ class Kohana_Model_Store_Refund extends Jam_Model {
 	 */
 	public function validate()
 	{
-		if ($this->total_amount() > $this->store_purchase->total_price(array('is_payable' => TRUE))) 
+		$refund_amount = $this->total_amount();
+		$store_purchase = $this->store_purchase_insist();
+		$previously_refunded_amount = $store_purchase->total_price('refund');
+		$store_purchase_not_refunded_amount = $store_purchase->total_price(array(
+			'is_payable' => TRUE,
+			'not' => 'refund',
+		));
+
+		if ($refund_amount->add($previously_refunded_amount)
+			->is(Jam_Price::GREATER_THAN, $store_purchase_not_refunded_amount))
 		{
 			$this->errors()->add('items', 'amount_more_than_store_purchase_price');
 		}

--- a/tests/tests/Model/Purchase/Item/RefundTest.php
+++ b/tests/tests/Model/Purchase/Item/RefundTest.php
@@ -13,7 +13,7 @@ class Model_Purchase_Item_RefundTest extends Testcase_Purchases {
 	{
 		$meta = Jam::meta('purchase_item_refund');
 		$this->assertSame('purchase_items', $meta->table());
-		$this->assertFalse($meta->field('is_payable')->default);
+		$this->assertTrue($meta->field('is_payable')->default);
 		$this->assertTrue($meta->field('is_discount')->default);
 	}
 


### PR DESCRIPTION
Refunds should reduce the final amount the customer has paid.

Everytime you write `total_price(array('is_payable' => TRUE))` you don't need
to think/know about refunds.

Before completing a purchase a refund cannot be created so it won't hurt the
process at all.

After a completed purchase you often want to get the amount the customer has
paid. I couldn't find the case where you'd want the original amount excluding
refunds.

(The only case where you'd want the original amount of the transaction is to
compute the transaction fee, but this surely happens before any refunds.)
