### PR TITLE
Use composer install --no-interaction in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 before_script:
   - mkdir -p build/logs
   - composer selfupdate
-  - composer install
+  - composer install --no-interaction
   - mysql -e 'create database `test-purchases`;'
   - mysql --default-character-set=utf8 test-purchases < tests/test_data/structure.sql
   - "export DISPLAY=:99.0"


### PR DESCRIPTION
When the GitHub API limit is reached the non-interaction mode would fallback to git cloning.

See https://github.com/composer/composer/issues/1314
