### PR TITLE
Iterate arrays when freezing to avoid reference issues

### DIFF
--- a/classes/Kohana/Model/Brand/Purchase.php
+++ b/classes/Kohana/Model/Brand/Purchase.php
@@ -280,7 +280,7 @@ class Kohana_Model_Brand_Purchase extends Jam_Model implements Purchasable, Free
 
 	public function performFreeze()
 	{
-		foreach ($this->items as $item)
+		foreach ($this->items->as_array() as $item)
 		{
 			$item->freeze();
 		}
@@ -290,7 +290,7 @@ class Kohana_Model_Brand_Purchase extends Jam_Model implements Purchasable, Free
 
 	public function performUnfreeze()
 	{
-		foreach ($this->items as $item)
+		foreach ($this->items->as_array() as $item)
 		{
 			$item->unfreeze();
 		}

--- a/classes/Kohana/Model/Purchase.php
+++ b/classes/Kohana/Model/Purchase.php
@@ -297,7 +297,7 @@ class Kohana_Model_Purchase extends Jam_Model implements Purchasable, FreezableI
 
 	public function freezeCollection()
 	{
-		foreach ($this->brand_purchases as $brand_purchase)
+		foreach ($this->brand_purchases->as_array() as $brand_purchase)
 		{
 			$brand_purchase->freeze();
 		}
@@ -305,7 +305,7 @@ class Kohana_Model_Purchase extends Jam_Model implements Purchasable, FreezableI
 
 	public function unfreezeCollection()
 	{
-		foreach ($this->brand_purchases as $brand_purchase)
+		foreach ($this->brand_purchases->as_array() as $brand_purchase)
 		{
 			$brand_purchase->unfreeze();
 		}


### PR DESCRIPTION
When iterating an association and perform an action which could access the parent model and then the same association is accessed by reference and nesting `foreach` loops is causing the internal pointer of the Iterator to move so the outer loop iteration is executed only once.

This may cause in multi-brand-purchase scenario, only some of purchase items to be frozen depending on the actions performed by the freeze.